### PR TITLE
Add profile login

### DIFF
--- a/src/application/use_cases/session/CreateSession.ts
+++ b/src/application/use_cases/session/CreateSession.ts
@@ -1,0 +1,33 @@
+import ProfileRepository from '../../../domain/ProfileRepository'
+
+interface Credentials {
+  email: string
+  password: string
+}
+
+interface Dependencies {
+  profileRepository: ProfileRepository
+}
+
+class CreateSessionUseCase {
+  private email: string
+  private password: string
+
+  readonly profileRepository: ProfileRepository
+
+  constructor ({ email, password }: Credentials, { profileRepository }: Dependencies) {
+    this.email = email
+    this.password = password
+
+    this.profileRepository = profileRepository
+  }
+
+  execute () {
+    return this.profileRepository.findByCredentials({
+      email: this.email,
+      password: this.password
+    })
+  }
+}
+
+export default CreateSessionUseCase

--- a/src/domain/ProfileRepository.ts
+++ b/src/domain/ProfileRepository.ts
@@ -1,5 +1,11 @@
 import Profile from './Profile'
 
+interface Credentials {
+  email: string
+  password: string
+}
+
 export default interface ProfileRepository {
   store(profile: Profile): Promise<Profile>
+  findByCredentials(credentials: Credentials): Promise<Profile>
 }

--- a/src/infrastructure/database/orm/entities/Profile.ts
+++ b/src/infrastructure/database/orm/entities/Profile.ts
@@ -4,7 +4,7 @@ import { Entity, Column, PrimaryColumn, Generated } from 'typeorm'
 class Profile {
   @PrimaryColumn()
   @Generated('uuid')
-  id!: string
+  id?: string
 
   @Column({ nullable: true })
   name?: string

--- a/src/infrastructure/database/orm/repository/ProfileRepository.ts
+++ b/src/infrastructure/database/orm/repository/ProfileRepository.ts
@@ -2,6 +2,12 @@ import { getManager } from 'typeorm'
 import Profile from '../../../../domain/Profile'
 import ProfileEntityFactory from '../factories/ProfileEntityFactory'
 import ProfileRepository from '../../../../domain/ProfileRepository'
+import ProfileEntity from '../entities/Profile'
+
+interface Credentials {
+  email: string
+  password: string
+}
 
 class ProfileRepositoryImpl implements ProfileRepository {
   async store (profile: Profile): Promise<Profile> {
@@ -10,6 +16,16 @@ class ProfileRepositoryImpl implements ProfileRepository {
     await getManager().save(profileEntity)
 
     return profileEntity
+  }
+
+  async findByCredentials ({ email, password }: Credentials): Promise<Profile> {
+    const profile = await getManager().findOne(ProfileEntity, { email, password })
+
+    if (!profile) {
+      throw new Error('Profile not found')
+    }
+
+    return new Profile(profile)
   }
 }
 

--- a/src/interface/http/controllers/SessionController.ts
+++ b/src/interface/http/controllers/SessionController.ts
@@ -1,0 +1,19 @@
+import ApplicationController from './ApplicationController'
+
+import CreateSessionUseCase from '../../../application/use_cases/session/CreateSession'
+import ProfileRepository from '../../../infrastructure/database/orm/repository/ProfileRepository'
+
+class SessionController extends ApplicationController {
+  async store () {
+    const { email, password } = this.req.body
+
+    const profile = await new CreateSessionUseCase(
+      { email, password },
+      { profileRepository: new ProfileRepository() }
+    ).execute()
+
+    this.res.status(200).send(profile)
+  }
+}
+
+export default SessionController

--- a/src/interface/http/routes/api.ts
+++ b/src/interface/http/routes/api.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 
 import ProfileController from '../controllers/ProfileController'
+import SessionController from '../controllers/SessionController'
 
 class Routes {
   readonly router: Router
@@ -9,10 +10,15 @@ class Routes {
     this.router = Router()
 
     this.mountProfilesRoutes()
+    this.mountSessionRoutes()
   }
 
   mountProfilesRoutes () {
     this.router.post('/profiles', (req, res) => new ProfileController(req, res).store())
+  }
+
+  mountSessionRoutes () {
+    this.router.post('/sessions', (req, res) => new SessionController(req, res).store())
   }
 }
 


### PR DESCRIPTION
We currently do not have an endpoint to handle log-in attempts. This PR fixes this by doing the following:

- Add session creator use case;
- Add repository method to find a profile matching given credentials;
- Add `POST: /sessions` endpoint to handle log in attempts;
